### PR TITLE
Fix array out of bounds crasher.

### DIFF
--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGalleryController/MHGalleryController.m
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGalleryController/MHGalleryController.m
@@ -58,6 +58,9 @@
 }
 
 -(MHGalleryItem *)itemForIndex:(NSInteger)index{
+    if (index < 0 || index >= [self numberOfItemsInGallery:self]) {
+        return nil;
+    }
     return self.galleryItems[index];
 }
 -(NSInteger)numberOfItemsInGallery:(MHGalleryController *)galleryController{


### PR DESCRIPTION
Hey Mario,

thanks for merging the last pull request (#43). Unfortunately one key part is missing now, the check for accessing the `self.galleryItems[index]` within the valid boundaries. If you run the current master branch you can still make the example app crash: Select an item with many images/videos and tap the right/left button very fast when you reach the beginning or end. So if it has 12 images, go to image `4 of 12` and hit the left button very fast, then it will crash:

`*** Terminating app due to uncaught exception 'NSRangeException', reason: '*** -[__NSArrayI objectAtIndex:]: index 4294967295 beyond bounds [0 .. 11]'`

Or go to image `8 of 12` and hit the right button very fast, then it will crash like this:

`*** Terminating app due to uncaught exception 'NSRangeException', reason: '*** -[__NSArrayI objectAtIndex:]: index 12 beyond bounds [0 .. 11]'`

If you need more information, please let me know!

Thanks,
Johannes
