### PR TITLE
Fix analyzer warnings.

### DIFF
--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGalleryImageViewerViewController/MHGalleryImageViewerViewController.m
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGalleryImageViewerViewController/MHGalleryImageViewerViewController.m
@@ -72,9 +72,10 @@
     MHTransitionDismissMHGallery *dismissTransiton = [MHTransitionDismissMHGallery new];
     dismissTransiton.orientationTransformBeforeDismiss = [(NSNumber *)[self.navigationController.view valueForKeyPath:@"layer.transform.rotation.z"] floatValue];
     imageViewer.interactiveTransition = dismissTransiton;
-    
-    if (self.galleryViewController && self.galleryViewController.finishedCallback) {
-        self.galleryViewController.finishedCallback(self.pageIndex,imageViewer.imageView.image,dismissTransiton,self.viewModeForBarStyle);
+
+    MHGalleryController *galleryViewController = [self galleryViewController];
+    if (galleryViewController.finishedCallback) {
+        galleryViewController.finishedCallback(self.pageIndex,imageViewer.imageView.image,dismissTransiton,self.viewModeForBarStyle);
     }
 }
 
@@ -676,8 +677,9 @@
                 self.interactiveTransition.interactive = YES;
                 self.interactiveTransition.moviePlayer = self.moviePlayer;
                 
-                if (self.viewController.galleryViewController && self.viewController.galleryViewController.finishedCallback) {
-                    self.viewController.galleryViewController.finishedCallback(self.pageIndex,self.imageView.image,self.interactiveTransition,self.viewController.viewModeForBarStyle);
+                MHGalleryController *galleryViewController = [self.viewController galleryViewController];
+                if (galleryViewController.finishedCallback) {
+                    galleryViewController.finishedCallback(self.pageIndex,self.imageView.image,self.interactiveTransition,self.viewController.viewModeForBarStyle);
                 }
                 
             }else{

--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHOverviewController/MHOverviewController.m
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHOverviewController/MHOverviewController.m
@@ -96,9 +96,10 @@
 
 -(void)donePressed{
     self.navigationController.transitioningDelegate = nil;
-    
-    if (self.galleryViewController && self.galleryViewController.finishedCallback) {
-        self.galleryViewController.finishedCallback(0,nil,nil,MHGalleryViewModeOverView);
+
+    MHGalleryController *galleryViewController = [self galleryViewController];
+    if (galleryViewController.finishedCallback) {
+        galleryViewController.finishedCallback(0,nil,nil,MHGalleryViewModeOverView);
     }
 }
 


### PR DESCRIPTION
Hey Mario,

this just fixes the warnings you get when you run the static analyzer in Xcode with cmd+shift+B. They are all false positives, your code was just fine before. Expressing it in a different way makes the static analyzer happy :).

Best regards,
Johannes
