### PR TITLE
Solve issue when tapping on a video

### DIFF
--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGalleryImageViewerViewController/MHGalleryImageViewerViewController.m
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGalleryImageViewerViewController/MHGalleryImageViewerViewController.m
@@ -1059,7 +1059,9 @@
     [self.view bringSubviewToFront:self.moviePlayer.view];
     
     self.moviewPlayerButtonBehinde = [UIButton.alloc initWithFrame:self.view.bounds];
-    [self.moviewPlayerButtonBehinde addTarget:self action:@selector(handelImageTap:) forControlEvents:UIControlEventTouchUpInside];
+    UITapGestureRecognizer *imageTap =[UITapGestureRecognizer.alloc initWithTarget:self action:@selector(handelImageTap:)];
+    imageTap.numberOfTapsRequired =1;
+    [self.moviewPlayerButtonBehinde addGestureRecognizer:imageTap];
     self.moviewPlayerButtonBehinde.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
     
     [self.view bringSubviewToFront:self.scrollView];
@@ -1362,9 +1364,11 @@
 
 -(void)handelImageTap:(UIGestureRecognizer *)gestureRecognizer{
     if (!self.viewController.isHiddingToolBarAndNavigationBar) {
-        CGPoint tappedLocation = [gestureRecognizer locationInView:self.view];
-        if (CGRectContainsPoint(self.moviePlayerToolBarTop.frame, tappedLocation)) {
-             return;
+        if ([gestureRecognizer isKindOfClass:[UIGestureRecognizer class]]) {
+            CGPoint tappedLocation = [gestureRecognizer locationInView:self.view];
+            if (CGRectContainsPoint(self.moviePlayerToolBarTop.frame, tappedLocation)) {
+                return;
+            }
         }
         
         [UIView animateWithDuration:0.3 animations:^{


### PR DESCRIPTION
The following method `-(void)handelImageTap:(UIGestureRecognizer *)gestureRecognizer` in MHGalleryImageViewerViewController was crashing my app when tapping on a video presented inside the `MHGalleryController`. The problem was due to the selector `locationInView:` called on an instance of UIButton. 

The `handelImageTap` method should actually accept only instances of UIGestureRecognizer as its parameters, but in `changeToPlayable` the `self.moviewPlayerButtonBehinde` is being passed as a parameter, thus crashing the app. 

I've solved the issue by adding a gesture recognizer to `self.moviewPlayerButtonBehinde` and by adding a defensive check inside `handelImageTap`.
