### PR TITLE
Fixed iOS 8 landscape moviePlayerToolbarTop position. (status bar hidden by default)

### DIFF
--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGalleryImageViewerViewController/MHGalleryImageViewerViewController.m
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGalleryImageViewerViewController/MHGalleryImageViewerViewController.m
@@ -1362,16 +1362,11 @@
 
 -(void)handelImageTap:(UIGestureRecognizer *)gestureRecognizer{
     if (!self.viewController.isHiddingToolBarAndNavigationBar) {
-        /*CGPoint tappedLocation = [gestureRecognizer locationInView:self.view];
-        if (CGRectContainsPoint(self.moviePlayerToolBarTop.frame, tappedLocation)) {
-             return;
-        }*/
         if ([gestureRecognizer respondsToSelector:@selector(locationInView:)]) {
             CGPoint tappedLocation = [gestureRecognizer locationInView:self.view];
-            if (CGRectContainsPoint(self.moviePlayerToolBarTop.frame, tappedLocation))
-            {
-                    return;
-                }
+            if (CGRectContainsPoint(self.moviePlayerToolBarTop.frame, tappedLocation)) {
+                return;
+            }
         }
         
         [UIView animateWithDuration:0.3 animations:^{


### PR DESCRIPTION
In iOS 8 status bar is hidden in landscape by default, causing moviePlayerToolbarTop to be placed 20points under navigation in landscape.

Modified the moviePlayerToolbarTop.frame to get Y axis position more dynamically. This way the code will check current status & size of both, status and navigation bar.
