### PR TITLE
Fixed rotation issue of Video Thumbnails.

### DIFF
--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGallerySharedManager/MHGallerySharedManager.m
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGallerySharedManager/MHGallerySharedManager.m
@@ -77,6 +77,7 @@
             AVURLAsset *asset=[AVURLAsset.alloc  initWithURL:url options:nil];
             
             AVAssetImageGenerator *generator = [AVAssetImageGenerator.alloc initWithAsset:asset];
+            generator.appliesPreferredTrackTransform = YES;
             CMTime thumbTime = CMTimeMakeWithSeconds(0,40);
             CMTime videoDurationTime = asset.duration;
             NSUInteger videoDurationTimeInSeconds = CMTimeGetSeconds(videoDurationTime);


### PR DESCRIPTION
The appliesPreferredTrackTransform = YES property tells the AVAssetImageGenerator to apply asset transformations to the generated thumbnail. This way, the video rotation is also applied to the thumbnail.