### PR TITLE
Fix iOS 8 with status bar improperly returning

### DIFF
--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGalleryImageViewerViewController/MHGalleryImageViewerViewController.m
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGalleryImageViewerViewController/MHGalleryImageViewerViewController.m
@@ -1380,8 +1380,9 @@
     BOOL greaterThanOrEqualToiOS8 = ([[[UIDevice currentDevice] systemVersion] compare:@"8.0" options:NSNumericSearch] != NSOrderedAscending);
     UIInterfaceOrientation currentOrientation = UIApplication.sharedApplication.statusBarOrientation;
     BOOL isLandscape = UIInterfaceOrientationIsLandscape(currentOrientation);
+    BOOL isPhone = UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone;
 
-    if (greaterThanOrEqualToiOS8 && isLandscape) {
+    if (greaterThanOrEqualToiOS8 && isLandscape && isPhone) {
         alpha = 0;
     }
 


### PR DESCRIPTION
In iOS 8, when rotated in landscape, status bars are now hidden by the system.

MHVideoPhotoGallery's awesome behavior of tapping while viewing a photo or video to hide/show the bars was not respecting this behavior and was improperly re-showing the status bar when performing these actions while in landscape.

Here's a screenshot of the issue occurring:

![ios simulator screen shot sep 29 2014 9 20 03 pm](https://cloud.githubusercontent.com/assets/119054/4453311/12d2bee8-4859-11e4-83a3-3c755197f77f.png)

It was reproducible 100% of the time.

This pull requests fixes this issue by not re-showing the status bar when it would have previously on devices running iOS 8 or higher (Also this pertains only to iPhone and iPod Touch devices, so I've made sure to preserve the original existing behavior on iPads).

Thanks for an awesome library, cheers!
