### PR TITLE
Update wholeTimeMovie if it was zero update it on player status change.

### DIFF
--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGalleryImageViewerViewController/MHGalleryImageViewerViewController.m
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGalleryImageViewerViewController/MHGalleryImageViewerViewController.m
@@ -1101,6 +1101,10 @@
 
 - (void)loadStateDidChange:(NSNotification *)notification{
 	MPMoviePlayerController *player = notification.object;
+    if (self.wholeTimeMovie == 0 && player.playableDuration != 0) {
+        self.wholeTimeMovie = player.playableDuration;
+        self.slider.maximumValue = player.playableDuration;
+    }
 	MPMovieLoadState loadState = player.loadState;
 	if (loadState & MPMovieLoadStatePlayable){
         if (!self.videoWasPlayable) {


### PR DESCRIPTION
In some cases (specially using the video player to play mp3 files), the play time is not available until the media starts playing, and the playing time bar and time labels are not set correctly.
When the movie player load status changes, I set the wholeTimeMovie property if it was 0 and the player has a new valid value.
