### PR TITLE
Fix Xcode 6.3 warnings

### DIFF
--- a/MHVideoPhotoGallery.xcodeproj/project.pbxproj
+++ b/MHVideoPhotoGallery.xcodeproj/project.pbxproj
@@ -932,12 +932,6 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					/Users/mario_hahn/Documents/Development/MHGallery,
-					/Users/mario_hahn/Documents/Development/MHGallery/MHVideoPhotoGallery,
-					"$(PROJECT_DIR)",
-				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MHVideoPhotoGallery/MHVideoPhotoGallery-Prefix.pch";
 				INFOPLIST_FILE = "MHVideoPhotoGallery/MHVideoPhotoGallery-Info.plist";
@@ -957,12 +951,6 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					/Users/mario_hahn/Documents/Development/MHGallery,
-					/Users/mario_hahn/Documents/Development/MHGallery/MHVideoPhotoGallery,
-					"$(PROJECT_DIR)",
-				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MHVideoPhotoGallery/MHVideoPhotoGallery-Prefix.pch";
 				INFOPLIST_FILE = "MHVideoPhotoGallery/MHVideoPhotoGallery-Info.plist";

--- a/MHVideoPhotoGallery/ExampleViewControllerCollectionViewInTableView.m
+++ b/MHVideoPhotoGallery/ExampleViewControllerCollectionViewInTableView.m
@@ -123,15 +123,7 @@
     
     MHGalleryItem *landschaft20 = [MHGalleryItem.alloc initWithURL:@"http://www.stadt-bad-reichenhall.de/medien/landschaft-1.jpg"
                                                        galleryType:MHGalleryTypeImage];
-    
-    MHGalleryItem *gif1 = [MHGalleryItem.alloc initWithURL:@"http://i.imgur.com/qe8wIgn.gif"
-                                                       galleryType:MHGalleryTypeImage];
-    
-    MHGalleryItem *gif2 = [MHGalleryItem.alloc initWithURL:@"http://i.imgur.com/d86g7Ps.gif"
-                                                       galleryType:MHGalleryTypeImage];
-    
-    
-    
+
     NSMutableAttributedString *string = [[NSMutableAttributedString alloc]initWithString:@"Awesome!!\nOr isn't it?"];
     
     [string setAttributes:@{NSFontAttributeName: [UIFont systemFontOfSize:15]} range:NSMakeRange(0, string.length)];

--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/Transitions/MHTransitionDismissMHGallery.m
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/Transitions/MHTransitionDismissMHGallery.m
@@ -284,14 +284,14 @@
                 if (!self.transitionImageView) {
                     CGPoint newPoint = self.startCenter;
                     if (self.cellImageSnapshot.center.x > self.startCenter.x) {
-                        newPoint.x = self.cellImageSnapshot.center.x + abs(self.cellImageSnapshot.center.x -self.startCenter.x)*4;
+                        newPoint.x = self.cellImageSnapshot.center.x + fabs(self.cellImageSnapshot.center.x -self.startCenter.x)*4;
                     }else{
-                        newPoint.x = self.cellImageSnapshot.center.x - abs(self.cellImageSnapshot.center.x -self.startCenter.x)*4;
+                        newPoint.x = self.cellImageSnapshot.center.x - fabs(self.cellImageSnapshot.center.x -self.startCenter.x)*4;
                     }
                     if (self.cellImageSnapshot.center.y > self.startCenter.y) {
-                        newPoint.y = self.cellImageSnapshot.center.y + abs(self.cellImageSnapshot.center.y -self.startCenter.y)*4;
+                        newPoint.y = self.cellImageSnapshot.center.y + fabs(self.cellImageSnapshot.center.y -self.startCenter.y)*4;
                     }else{
-                        newPoint.y = self.cellImageSnapshot.center.y - abs(self.cellImageSnapshot.center.y -self.startCenter.y)*4;
+                        newPoint.y = self.cellImageSnapshot.center.y - fabs(self.cellImageSnapshot.center.y -self.startCenter.y)*4;
                     }
                     self.cellImageSnapshot.center = newPoint;
                 }else{

--- a/MHVideoPhotoGallery/Storyboard-iPad.storyboard
+++ b/MHVideoPhotoGallery/Storyboard-iPad.storyboard
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="5051" systemVersion="13C64" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" initialViewController="FiE-fE-DM5">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7515.2" systemVersion="14C109" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" initialViewController="FiE-fE-DM5">
     <dependencies>
-        <deployment defaultVersion="1552" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7512"/>
     </dependencies>
     <scenes>
         <!--Navigation Controller-->
         <scene sceneID="aCw-Vh-w4c">
             <objects>
-                <navigationController definesPresentationContext="YES" id="emX-eX-E4u" sceneMemberID="viewController">
+                <navigationController storyboardIdentifier="UINavigationControllerWith ExampleViewController" definesPresentationContext="YES" id="emX-eX-E4u" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="FmV-WK-0Y7">
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -34,7 +34,6 @@
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" translatesAutoresizingMaskIntoConstraints="NO" id="kp1-LK-FI4">
                                 <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                 <connections>
                                     <outlet property="dataSource" destination="WTF-am-qxF" id="tP0-nX-CdD"/>
@@ -67,7 +66,6 @@
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="315" sectionHeaderHeight="10" sectionFooterHeight="10" translatesAutoresizingMaskIntoConstraints="NO" id="NED-bC-lny">
                                 <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" white="0.66666666669999997" alpha="0.40000000000000002" colorSpace="calibratedWhite"/>
                                 <color key="sectionIndexTrackingBackgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <prototypes>
@@ -80,12 +78,10 @@
                                             <subviews>
                                                 <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jyj-dk-Xl6">
                                                     <rect key="frame" x="10" y="4" width="738" height="318"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                 </view>
                                                 <collectionView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" minimumZoomScale="0.0" maximumZoomScale="0.0" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="3rg-LU-kbU">
                                                     <rect key="frame" x="-5" y="80" width="773" height="230"/>
-                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                                     <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="apo-dG-LCy">
                                                         <size key="itemSize" width="50" height="50"/>
@@ -97,24 +93,20 @@
                                                 </collectionView>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="testIcon.png" translatesAutoresizingMaskIntoConstraints="NO" id="8T4-Hr-4BB">
                                                     <rect key="frame" x="20" y="12" width="40" height="40"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 </imageView>
                                                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Mario Hahn" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gaf-lN-EG9">
                                                     <rect key="frame" x="70" y="12" width="157" height="21"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                                     <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Mario Hahn added new photos to his album" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="290" translatesAutoresizingMaskIntoConstraints="NO" id="Hq5-eB-RRN">
                                                     <rect key="frame" x="20" y="46" width="290" height="42"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" name="HelveticaNeue-Light" family="Helvetica Neue" pointSize="14"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="20 min ago" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qUG-el-nfK">
                                                     <rect key="frame" x="70" y="34" width="139" height="21"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="14"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                     <nil key="highlightedColor"/>

--- a/MHVideoPhotoGallery/Storyboard.storyboard
+++ b/MHVideoPhotoGallery/Storyboard.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14C81f" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="mXS-gW-vdx">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7515.2" systemVersion="14C109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="mXS-gW-vdx">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7512"/>
     </dependencies>
     <scenes>
         <!--Tab Bar Controller-->
@@ -45,7 +45,7 @@
         <!--Navigation Controller-->
         <scene sceneID="fW5-aL-gPS">
             <objects>
-                <navigationController definesPresentationContext="YES" id="04z-gI-uag" sceneMemberID="viewController">
+                <navigationController storyboardIdentifier="UINavigationControllerWith SubclassMHImageviewerViewController" definesPresentationContext="YES" id="04z-gI-uag" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="8Cc-6V-y4W">
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -234,97 +234,6 @@
             </objects>
             <point key="canvasLocation" x="852" y="-550"/>
         </scene>
-        <!--Example View Controller Collection View In Table View-->
-        <scene sceneID="FO6-1C-Fal">
-            <objects>
-                <viewController id="eMq-jH-vnJ" customClass="ExampleViewControllerCollectionViewInTableView" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="MeA-8L-RCF"/>
-                        <viewControllerLayoutGuide type="bottom" id="eHc-Vx-UAe"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="VUi-kN-J9J">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="315" sectionHeaderHeight="10" sectionFooterHeight="10" translatesAutoresizingMaskIntoConstraints="NO" id="Rlw-TH-d8U">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
-                                <color key="backgroundColor" white="0.66666666669999997" alpha="0.40000000000000002" colorSpace="calibratedWhite"/>
-                                <color key="sectionIndexTrackingBackgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                <prototypes>
-                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="TestCell" rowHeight="330" id="0g9-dK-y0E" customClass="TestCell">
-                                        <rect key="frame" x="0.0" y="55" width="320" height="330"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="0g9-dK-y0E" id="fcu-pb-fGD">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="330"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZvK-qE-0ak">
-                                                    <rect key="frame" x="10" y="4" width="300" height="318"/>
-                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                                </view>
-                                                <collectionView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" minimumZoomScale="0.0" maximumZoomScale="0.0" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="vaE-8Q-g8Z">
-                                                    <rect key="frame" x="-5" y="80" width="325" height="230"/>
-                                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                                    <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="2dc-98-4GL">
-                                                        <size key="itemSize" width="50" height="50"/>
-                                                        <size key="headerReferenceSize" width="0.0" height="0.0"/>
-                                                        <size key="footerReferenceSize" width="0.0" height="0.0"/>
-                                                        <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                                    </collectionViewFlowLayout>
-                                                    <cells/>
-                                                </collectionView>
-                                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="testIcon.png" translatesAutoresizingMaskIntoConstraints="NO" id="xuf-OC-m3Y">
-                                                    <rect key="frame" x="20" y="12" width="40" height="40"/>
-                                                </imageView>
-                                                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Mario Hahn" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2pd-TB-ajX">
-                                                    <rect key="frame" x="70" y="12" width="157" height="21"/>
-                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Mario Hahn added new photos to his album" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="290" translatesAutoresizingMaskIntoConstraints="NO" id="7ns-yZ-d5X">
-                                                    <rect key="frame" x="20" y="46" width="290" height="42"/>
-                                                    <fontDescription key="fontDescription" name="HelveticaNeue-Light" family="Helvetica Neue" pointSize="14"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="20 min ago" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tn7-sE-H0c">
-                                                    <rect key="frame" x="70" y="34" width="139" height="21"/>
-                                                    <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="14"/>
-                                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                        <connections>
-                                            <outlet property="backView" destination="ZvK-qE-0ak" id="lsE-dF-B4B"/>
-                                            <outlet property="collectionView" destination="vaE-8Q-g8Z" id="q14-Bf-C4K"/>
-                                        </connections>
-                                    </tableViewCell>
-                                </prototypes>
-                                <connections>
-                                    <outlet property="dataSource" destination="eMq-jH-vnJ" id="sDg-bq-O5f"/>
-                                    <outlet property="delegate" destination="eMq-jH-vnJ" id="vA6-Zw-peF"/>
-                                </connections>
-                            </tableView>
-                        </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
-                        <constraints>
-                            <constraint firstItem="eHc-Vx-UAe" firstAttribute="top" secondItem="Rlw-TH-d8U" secondAttribute="bottom" id="AiF-yF-AMH"/>
-                            <constraint firstAttribute="trailing" secondItem="Rlw-TH-d8U" secondAttribute="trailing" id="VXK-71-R8z"/>
-                            <constraint firstItem="Rlw-TH-d8U" firstAttribute="top" secondItem="VUi-kN-J9J" secondAttribute="top" id="d65-Or-Xgt"/>
-                            <constraint firstItem="Rlw-TH-d8U" firstAttribute="leading" secondItem="VUi-kN-J9J" secondAttribute="leading" id="s80-IF-JoB"/>
-                        </constraints>
-                    </view>
-                    <navigationItem key="navigationItem" id="P33-T8-jMm"/>
-                    <connections>
-                        <outlet property="tableView" destination="Rlw-TH-d8U" id="4sx-bE-yeq"/>
-                    </connections>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="cPZ-pU-VkJ" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-388" y="450"/>
-        </scene>
         <!--TableView-->
         <scene sceneID="hoo-t6-jeb">
             <objects>
@@ -401,7 +310,7 @@
         <!--Instagram-->
         <scene sceneID="Err-6R-RgN">
             <objects>
-                <navigationController definesPresentationContext="YES" id="jKW-PO-ujo" sceneMemberID="viewController">
+                <navigationController storyboardIdentifier="UINavigationControllerWith InstagramViewController" definesPresentationContext="YES" id="jKW-PO-ujo" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="Instagram" image="707-albums-selected" id="x8X-r6-UzZ"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="Klw-Z1-hnG">
                         <autoresizingMask key="autoresizingMask"/>


### PR DESCRIPTION
Hey Mario,

when opening the project on Xcode 6.3 it reveals some new warnings (the ones regarding `abs` vs. `fabs`. The pull request will fix these warnings.

I've also fixed a few others:

* Unreachable storyboard scenes
* Framework search path hardcoded to your local setup (`/Users/mario_hahn/Documents/Development/MHGallery` and `/Users/mario_hahn/Documents/Development/MHGallery/MHVideoPhotoGallery`)
* Unused variables in the example project

Cheers,
plu