### PR TITLE
sharedManager renamed in sharedInstance to add compatibility to swift

### DIFF
--- a/MHVideoPhotoGallery/ExampleViewControllerLocal.m
+++ b/MHVideoPhotoGallery/ExampleViewControllerLocal.m
@@ -82,7 +82,7 @@
     
     MHGalleryItem *item = [section.galleryItems firstObject];
     
-    [[MHGallerySharedManager sharedManager] getImageFromAssetLibrary:item.URLString
+    [[MHGallerySharedManager sharedInstance] getImageFromAssetLibrary:item.URLString
                                                            assetType:MHAssetImageTypeThumb
                                                         successBlock:^(UIImage *image, NSError *error) {
         cell.iv.image = image;

--- a/MHVideoPhotoGallery/ExampleViewControllerTableView.m
+++ b/MHVideoPhotoGallery/ExampleViewControllerTableView.m
@@ -88,7 +88,7 @@
     if(item.galleryType == MHGalleryTypeImage){
         [cell.iv sd_setImageWithURL:[NSURL URLWithString:item.URLString]];
     }else{
-        [[MHGallerySharedManager sharedManager] startDownloadingThumbImage:item.URLString
+        [[MHGallerySharedManager sharedInstance] startDownloadingThumbImage:item.URLString
                                                               successBlock:^(UIImage *image, NSUInteger videoDuration, NSError *error) {
                                                                   cell.iv.image = image;
                                                               }];

--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGalleryImageViewerViewController/MHGalleryImageViewerViewController.m
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGalleryImageViewerViewController/MHGalleryImageViewerViewController.m
@@ -878,7 +878,7 @@
             }];
             
         }else{
-            [MHGallerySharedManager.sharedManager startDownloadingThumbImage:self.item.URLString
+            [MHGallerySharedManager.sharedInstance startDownloadingThumbImage:self.item.URLString
                                                                 successBlock:^(UIImage *image,NSUInteger videoDuration,NSError *error) {
                                                                     if (!error) {
                                                                         [weakSelf handleGeneratedThumb:image
@@ -924,7 +924,7 @@
             [weakSelf autoPlayVideo];
             return;
         }
-        [[MHGallerySharedManager sharedManager] getURLForMediaPlayer:self.item.URLString successBlock:^(NSURL *URL, NSError *error) {
+        [[MHGallerySharedManager sharedInstance] getURLForMediaPlayer:self.item.URLString successBlock:^(NSURL *URL, NSError *error) {
             if (error || URL == nil) {
                 [weakSelf changePlayButtonToUnPlay];
             }else{

--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGallerySharedManager/MHGallerySharedManager.h
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGallerySharedManager/MHGallerySharedManager.h
@@ -78,7 +78,7 @@ typedef NS_ENUM(NSUInteger, MHYoutubeThumbQuality) {
  */
 @property (nonatomic,assign) MHYoutubeVideoQuality youtubeVideoQuality;
 
-+ (MHGallerySharedManager *)sharedManager;
++ (MHGallerySharedManager *)sharedInstance;
 /**
  *  You can create a Thumbnail from a Video, you can create it from Videos from a Webserver, Youtube and Vimeo
  *

--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGallerySharedManager/MHGallerySharedManager.m
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGallerySharedManager/MHGallerySharedManager.m
@@ -11,7 +11,7 @@
 
 @implementation MHGallerySharedManager
 
-+ (MHGallerySharedManager *)sharedManager{
++ (MHGallerySharedManager *)sharedInstance{
     static MHGallerySharedManager *sharedManagerInstance = nil;
     static dispatch_once_t onceQueue;
     dispatch_once(&onceQueue, ^{

--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHMediaPreviewCollectionViewCell/MHMediaPreviewCollectionViewCell.m
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHMediaPreviewCollectionViewCell/MHMediaPreviewCollectionViewCell.m
@@ -82,7 +82,7 @@
     [self.activityIndicator startAnimating];
 
     if (galleryItem.galleryType == MHGalleryTypeVideo) {
-        [MHGallerySharedManager.sharedManager startDownloadingThumbImage:galleryItem.URLString
+        [MHGallerySharedManager.sharedInstance startDownloadingThumbImage:galleryItem.URLString
                                                             successBlock:^(UIImage *image,NSUInteger videoDuration,NSError *error) {
                                                                 if (error) {
                                                                     weakSelf.thumbnail.backgroundColor = UIColor.whiteColor;

--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHOverviewController/MHOverviewController.m
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHOverviewController/MHOverviewController.m
@@ -261,7 +261,7 @@
     }
     if ([item.URLString rangeOfString:MHAssetLibrary].location != NSNotFound && item.URLString) {
         
-        [MHGallerySharedManager.sharedManager getImageFromAssetLibrary:item.URLString
+        [MHGallerySharedManager.sharedInstance getImageFromAssetLibrary:item.URLString
                                                              assetType:MHAssetImageTypeFull
                                                           successBlock:^(UIImage *image, NSError *error) {
                                                               cell.thumbnail.image = image;

--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHShareViewController/MHShareViewController.m
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHShareViewController/MHShareViewController.m
@@ -799,7 +799,7 @@
                 MHImageURL *imageURL = [MHImageURL.alloc initWithURL:item.URLString image:nil];
                 [weakSelf addDataToDownloadArray:imageURL];
             }else{
-                [MHGallerySharedManager.sharedManager getURLForMediaPlayer:item.URLString successBlock:^(NSURL *URL, NSError *error) {
+                [MHGallerySharedManager.sharedInstance getURLForMediaPlayer:item.URLString successBlock:^(NSURL *URL, NSError *error) {
                     NSURLSession *session = [NSURLSession sessionWithConfiguration:NSURLSessionConfiguration.defaultSessionConfiguration];
                     
                     [self.sessions addObject:session];
@@ -836,7 +836,7 @@
         if (item.galleryType == MHGalleryTypeImage) {
             
             if ([item.URLString rangeOfString:MHAssetLibrary].location != NSNotFound && item.URLString) {
-                [MHGallerySharedManager.sharedManager getImageFromAssetLibrary:item.URLString
+                [MHGallerySharedManager.sharedInstance getImageFromAssetLibrary:item.URLString
                                                                      assetType:MHAssetImageTypeFull
                                                                   successBlock:^(UIImage *image, NSError *error) {
                                                                       MHImageURL *imageURL = [MHImageURL.alloc initWithURL:item.URLString

--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/UIImageView+MHGallery/UIImageView+MHGallery.m
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/UIImageView+MHGallery/UIImageView+MHGallery.m
@@ -18,7 +18,7 @@
     
     __weak typeof(self) weakSelf = self;
     
-    [MHGallerySharedManager.sharedManager startDownloadingThumbImage:URL
+    [MHGallerySharedManager.sharedInstance startDownloadingThumbImage:URL
                                                         successBlock:^(UIImage *image, NSUInteger videoDuration, NSError *error) {
                                                             
                                                             if (!weakSelf) return;
@@ -47,7 +47,7 @@
             assetType = MHAssetImageTypeFull;
         }
         
-        [MHGallerySharedManager.sharedManager getImageFromAssetLibrary:item.URLString
+        [MHGallerySharedManager.sharedInstance getImageFromAssetLibrary:item.URLString
                                                              assetType:assetType
                                                           successBlock:^(UIImage *image, NSError *error) {
                                                               [weakSelf setImageForImageView:image successBlock:succeedBlock];


### PR DESCRIPTION
if you use this library in a swift project, you can't access
MHGallerySharedManager.sharedManager().
The compiler complains because it can't see sharedManager.
I looked around and find a fix thanks to this article
http://justinmiller.io/posts/2015/01/28/swift-objc-initializers/
So if you rename sharedManager in sharedInstance you are able to access
the singleton instance like this:
MHGallerySharedManager.sharedInstance().webPointForThumb