### PR TITLE
Fix status bar show/hide logic

### DIFF
--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGallery/MHGallery.h
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGallery/MHGallery.h
@@ -42,6 +42,7 @@ extern UIImage *MHDefaultImageForFrame(CGRect frame);
 extern UIImage  *MHGalleryImage(NSString *imageName);
 
 extern UIView  *MHStatusBar(void);
+extern BOOL     MHShouldShowStatusBar(void);
 
 extern NSString *const MHYoutubeChannel;
 extern NSString *const MHGalleryViewModeShare;

--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGallery/MHGallery.m
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGallery/MHGallery.m
@@ -66,6 +66,15 @@ UIView *MHStatusBar(void){
     return statusBar;
 }
 
+BOOL MHShouldShowStatusBar(void){
+    UIInterfaceOrientation currentOrientation = UIApplication.sharedApplication.statusBarOrientation;
+    BOOL isLandscape = UIInterfaceOrientationIsLandscape(currentOrientation);
+    BOOL isPhone = UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone;
+    if (MHGalleryOSVersion >= 8.0 && isLandscape && isPhone) {
+        return NO;
+    }
+    return YES;
+}
 
 UIImage *MHTemplateImage(NSString *imageName){
     return [MHGalleryImage(imageName) imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];

--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGalleryImageViewerViewController/MHGalleryImageViewerViewController.m
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGalleryImageViewerViewController/MHGalleryImageViewerViewController.m
@@ -734,7 +734,7 @@
                 }
                 
                 if (progressY > 0.35 || velocityY >700) {
-                    MHStatusBar().alpha =1;
+                    MHStatusBar().alpha = MHShouldShowStatusBar() ? 1 : 0;
                     [self.interactiveTransition finishInteractiveTransition];
                 }else {
                     [self setNeedsStatusBarAppearanceUpdate];
@@ -1379,11 +1379,7 @@
     self.viewController.descriptionView.alpha =alpha;
     self.viewController.descriptionViewBackground.alpha =alpha;
 
-    UIInterfaceOrientation currentOrientation = UIApplication.sharedApplication.statusBarOrientation;
-    BOOL isLandscape = UIInterfaceOrientationIsLandscape(currentOrientation);
-    BOOL isPhone = UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone;
-
-    if (MHGalleryOSVersion >= 8.0 && isLandscape && isPhone) {
+    if (!MHShouldShowStatusBar()) {
         alpha = 0;
     }
     MHStatusBar().alpha =alpha;

--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/Transitions/MHTransitionDismissMHGallery.m
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/Transitions/MHTransitionDismissMHGallery.m
@@ -273,7 +273,7 @@
         }
         
         [UIView animateWithDuration:0.3 animations:^{
-            MHStatusBar().alpha =1;
+            MHStatusBar().alpha = MHShouldShowStatusBar() ? 1 : 0;
             
             self.cellImageSnapshot.clipsToBounds = self.transitionImageView.clipsToBounds;
             self.cellImageSnapshot.layer.cornerRadius = self.transitionImageView.layer.cornerRadius;

--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/Transitions/MHTransitionShowOverView.m
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/Transitions/MHTransitionShowOverView.m
@@ -212,7 +212,7 @@
     [UIView animateWithDuration:0.3 animations:^{
         if (self.isHiddingToolBarAndNavigationBar) {
             self.toViewController.navigationController.navigationBar.alpha = 1;
-            MHStatusBar().alpha =1;
+            MHStatusBar().alpha = MHShouldShowStatusBar() ? 1 : 0;
         }
         self.toolbar.alpha = 0;
         self.descriptionLabel.alpha =0;


### PR DESCRIPTION
Hi,

on iOS 8 in landscape, the status bar is hidden by default. But there were some code paths in this library, that would set the alpha value to `1`. I have fixed these code paths so this does not happen anymore.

What is the reason for the `MHStatusBar` hack exactly :)? I understand what it does, but I don't understand the reason why it's there. If you find the time, it would be nice if you could explain it to me :).

Thanks,
Johannes

--

Steps to reproduce (on iOS 8.x):

* Go to the TableView tab
* Open any image
* Rotate device to landscape
* OK: Status bar is not there
* Tap again on the image to make it full screen
* Dismiss via tap & move gesture
* NOK: The status bar is there

![ios simulator screen shot 11 may 2015 16 25 23](https://cloud.githubusercontent.com/assets/31597/7567710/cce3bfbc-f7fe-11e4-990e-73b2c7dbf1a9.png)
