### PR TITLE
Fix build errors when installed via CocoaPods with use_frameworks! flag

### DIFF
--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGallery/MHGallery.h
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGallery/MHGallery.h
@@ -18,8 +18,8 @@
 #import "MHTransitionShowOverView.h"
 #import "MHGalleryImageViewerViewController.h"
 
-#import "SDWebImageDecoder.h"
-#import "SDImageCache.h"
+#import <SDWebImage/SDWebImageDecoder.h>
+#import <SDWebImage/SDImageCache.h>
 
 #define MHISIPAD ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad)
 #define kMHGalleryBundleName @"MHGallery.bundle"

--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHOverviewController/MHOverviewController.h
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHOverviewController/MHOverviewController.h
@@ -9,9 +9,9 @@
 #import <UIKit/UIKit.h>
 #import "MHGallery.h"
 #import "MHGalleryImageViewerViewController.h"
-#import "SDWebImageManager.h"
 #import "MHTransitionShowDetail.h"
 #import "MHMediaPreviewCollectionViewCell.h"
+#import <SDWebImage/SDWebImageManager.h>
 
 
 @interface MHIndexPinchGestureRecognizer : UIPinchGestureRecognizer


### PR DESCRIPTION
When this library is installed via CocoaPods with use_frameworks! flag, building the project that uses it fails with an error saying that the SDWebImage headers are not found. This PR fixes it.