### PR TITLE
Thumbnail and duration

### DIFF
--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGallery/MHGallery.h
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGallery/MHGallery.h
@@ -44,11 +44,13 @@ extern UIImage  *MHGalleryImage(NSString *imageName);
 extern UIView  *MHStatusBar(void);
 extern BOOL     MHShouldShowStatusBar(void);
 
+extern NSString *const MHYoutubeApiKey;
 extern NSString *const MHYoutubeChannel;
 extern NSString *const MHGalleryViewModeShare;
 extern NSString *const MHVimeoVideoBaseURL;
 extern NSString *const MHVimeoThumbBaseURL;
 extern NSString *const MHYoutubeInfoBaseURL;
+extern NSString *const MHYoutubeThumbBaseURL;
 extern NSString *const MHYoutubePlayBaseURL;
 extern NSString *const MHYoutubeBaseURL;
 extern NSString *const MHVimeoBaseURL;

--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGallery/MHGallery.m
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGallery/MHGallery.m
@@ -3,10 +3,12 @@
 #import "MHOverviewController.h"
 #import <objc/runtime.h>
 
-NSString * const MHYoutubeBaseURL          = @"http://www.youtube.com/watch?v=%@";
+NSString * const MHYoutubeApiKey           = @"<YOUR-API-KEY>";
+NSString * const MHYoutubeBaseURL          = @"https://www.youtube.com/watch?v=%@";
 NSString * const MHYoutubeChannel          = @"https://gdata.youtube.com/feeds/api/users/%@/uploads?&max-results=50&alt=json";
 NSString * const MHYoutubePlayBaseURL      = @"https://www.youtube.com/get_video_info?video_id=%@&el=embedded&ps=default&eurl=&gl=US&hl=%@";
-NSString * const MHYoutubeInfoBaseURL      = @"http://gdata.youtube.com/feeds/api/videos/%@?v=2&alt=jsonc";
+NSString * const MHYoutubeInfoBaseURL      = @"https://www.googleapis.com/youtube/v3/videos?part=contentDetails&id=%@&key=%@";
+NSString * const MHYoutubeThumbBaseURL     = @"https://i.ytimg.com/vi/";
 NSString * const MHVimeoThumbBaseURL       = @"http://vimeo.com/api/v2/video/%@.json";
 NSString * const MHVimeoVideoBaseURL       = @"http://player.vimeo.com/video/%@/config";
 NSString * const MHVimeoBaseURL            = @"http://vimeo.com/%@";

--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGallerySharedManager/MHGallerySharedManager.m
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGallerySharedManager/MHGallerySharedManager.m
@@ -288,7 +288,9 @@
         succeedBlock(image,[dict[URL] integerValue],nil);
     }else{
         NSString *videoID = [[URL componentsSeparatedByString:@"?v="] lastObject];
-        NSString *infoURL = [NSString stringWithFormat:MHYoutubeInfoBaseURL,videoID];
+        NSString *infoURL = [self stringWithString:MHYoutubeInfoBaseURL andArgumentsArray:@[videoID,MHYoutubeApiKey]];
+        NSLog(@"INFO URL %@",infoURL);
+        
         NSMutableURLRequest *httpRequest = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:infoURL]
                                                                    cachePolicy:NSURLRequestUseProtocolCachePolicy
                                                                timeoutInterval:10];
@@ -302,14 +304,19 @@
                                                                                                   error:&error];
                                        dispatch_async(dispatch_get_main_queue(), ^(void){
                                            if (jsonData.count) {
+                                               NSLog(@"JSON \n%@",jsonData);
                                                NSMutableDictionary *dictToSave = [self durationDict];
-                                               dictToSave[URL] = @([jsonData[@"data"][@"duration"] integerValue]);
+                                               NSLog(@"Duration %@",jsonData[@"items"][0][@"contentDetails"][@"duration"]);
+                                               NSString *duration = jsonData[@"items"][0][@"contentDetails"][@"duration"];
+                                               NSInteger intDuration = [self integerFromYoutubeDurationString:duration];
+                                               dictToSave[URL] = @(intDuration);
                                                [self setObjectToUserDefaults:dictToSave];
-                                               NSString *thumbURL = NSString.new;
+                                               NSString *thumbURL = nil;
+                                               
                                                if (self.youtubeThumbQuality == MHYoutubeThumbQualityHQ) {
-                                                   thumbURL = jsonData[@"data"][@"thumbnail"][@"hqDefault"];
+                                                   thumbURL = [NSString stringWithFormat:@"%@%@/hqdefault.jpg",MHYoutubeThumbBaseURL,videoID];
                                                }else if (self.youtubeThumbQuality == MHYoutubeThumbQualitySQ){
-                                                   thumbURL = jsonData[@"data"][@"thumbnail"][@"sqDefault"];
+                                                   thumbURL = [NSString stringWithFormat:@"%@%@/sddefault.jpg",MHYoutubeThumbBaseURL,videoID];
                                                }
                                                [SDWebImageManager.sharedManager downloadImageWithURL:[NSURL URLWithString:thumbURL]
                                                                                              options:SDWebImageContinueInBackground
@@ -320,7 +327,7 @@
                                                                                                [SDImageCache.sharedImageCache storeImage:image
                                                                                                                                   forKey:URL];
                                                                                                
-                                                                                               succeedBlock(image,[jsonData[@"data"][@"duration"] integerValue],nil);
+                                                                                               succeedBlock(image,intDuration,nil);
                                                                                            }];
                                            }
                                        });
@@ -456,6 +463,66 @@
     }];
 }
 
+/*!
+ * @brief convert duration from Youtube format to NSInteger
+ *
+ * @param duration duration's video
+
+ *
+ * @return return  totalSeconds as NSInteger
+ **/
+- (NSInteger)integerFromYoutubeDurationString:(NSString*)duration{
+    
+    if(duration == nil){
+        return 0;
+    }
+    
+    
+    NSString *startConst = @"PT";
+    NSString *hoursConst = @"H";
+    NSString *minutesConst = @"M";
+    NSString *secondsConst = @"S";
+    NSString *hours = nil;
+    NSString *minutes = nil;
+    NSString *seconds = nil;
+    NSInteger totalSeconds = 0;
+    
+    NSString *clean = [duration componentsSeparatedByString:startConst][1];
+    
+    if([clean containsString:hoursConst]){
+        hours = [clean componentsSeparatedByString:hoursConst][0];
+        clean = [clean componentsSeparatedByString:hoursConst][1];
+        totalSeconds = [hours integerValue]*3600;
+    }
+    if([clean containsString:minutesConst]){
+        minutes = [clean componentsSeparatedByString:minutesConst][0];
+        clean = [clean componentsSeparatedByString:minutesConst][1];
+        totalSeconds = totalSeconds + [minutes integerValue]*60;
+    }
+    if([clean containsString:secondsConst]){
+        seconds = [clean componentsSeparatedByString:secondsConst][0];
+        totalSeconds = totalSeconds + [seconds integerValue];
+    }
+
+    return totalSeconds;
+}
+
+
+/**
+ *
+ * Create NSString with given arguments in NSArray
+ *
+ **/
+- (NSString*)stringWithString:(NSString *)string andArgumentsArray:(NSArray*) arguments
+{
+    NSString *tmpString = string;
+    
+    for (NSString *currentReplacement in arguments){
+       tmpString = [tmpString stringByReplacingCharactersInRange:[tmpString rangeOfString:@"%@"]
+                                        withString:currentReplacement];
+    }
+    return tmpString;
+}
 
 +(NSString*)stringForMinutesAndSeconds:(NSInteger)seconds
                               addMinus:(BOOL)addMinus{


### PR DESCRIPTION
Referred to [issue 109] (https://github.com/mariohahn/MHVideoPhotoGallery/issues/109)
The original implementation was did with API v2 which are deprecated
right now. I replaced the old implementation with the new that requires
an API key generated from Google Api Console, this key must be
specified at row 6 of MHGallery.m through the const string
MHYoutubeApiKey. Really, only the duration need to be called via v3 API
because the thumbnails are available without API call (a little trick).
I know that’s a quick and dirty solution in fact, the rest part of
library will have to be modified.
